### PR TITLE
Initalize rampup coaches

### DIFF
--- a/areas/rebbl/league.js
+++ b/areas/rebbl/league.js
@@ -23,13 +23,13 @@ router.get('/', util.checkCache, async function(req, res){
     league = new RegExp(`^${league}`, 'i');
   }
 
-  data.cutoffs = configuration.getPlayoffTickets(req.params.league);
   
   if( req.params.league.toLowerCase() === "rampup"){
     data.standings = await rampup.getCoachScore();
     data.rounds = await db.getDivisions(new RegExp(/rampup$/,"i"));
     res.render('rebbl/league/rampup', data);
   } else {
+    data.cutoffs = configuration.getPlayoffTickets(req.params.league);
     data.standings = await db.getCoachScore(league, null, true);
     data.rounds = await db.getDivisions(league);
     res.render('rebbl/league/index', data);

--- a/lib/Rampup.js
+++ b/lib/Rampup.js
@@ -6,12 +6,55 @@ class Rampup {
   }
 
   async getCoachScore() {
+    let coaches = [];
     let schedules = await this.leagueService.searchLeagues({"league": {"$regex": new RegExp(/rampup$/,"i")}, "status":"played", "match_uuid":{$gt:"100054a72d"}});
 
-    //get all coach id's
     let coachHome = schedules.map(schedule => schedule.opponents[0].coach.id);
     let coachAway = schedules.map(schedule => schedule.opponents[1].coach.id);
     let ids = [...new Set([...coachAway, ...coachHome])];
+    
+    //init coaches, so we know which rampup they are part of
+    schedules.forEach(function (schedule) {
+      let coach = coaches.find(c => c.id === schedule.opponents[0].coach.id);
+      if (!coach && ids.indexOf(schedule.opponents[0].coach.id) > -1) {
+          coach = {
+            competition: schedule.competition,
+            id: schedule.opponents[0].coach.id,
+            name: schedule.opponents[0].coach.name,
+            team: schedule.opponents[0].team.name,
+            teamId: schedule.opponents[0].team.id,
+            race: schedule.opponents[0].team.race,
+            points: 0,
+            games: 0,
+            win: 0,
+            loss: 0,
+            draw: 0,
+            tddiff: 0
+          };
+          coaches.push(coach);
+      }
+      coach = coaches.find(c => c.id === schedule.opponents[1].coach.id);
+      if (!coach && ids.indexOf(schedule.opponents[1].coach.id) > -1 ) {
+          coach = {
+            competition: schedule.competition,
+            id: schedule.opponents[1].coach.id,
+            name: schedule.opponents[1].coach.name,
+            team: schedule.opponents[1].team.name,
+            teamId: schedule.opponents[1].team.id,
+            race: schedule.opponents[1].team.race,
+            points: 0,
+            games: 0,
+            win: 0,
+            loss: 0,
+            draw: 0,
+            tddiff: 0
+          };
+          coaches.push(coach);
+      }
+    });
+
+    //get all coach id's
+
 
     if (ids.indexOf(111960) > -1) ids.splice(ids.indexOf(111960),1 );
     if (ids.indexOf(null) > -1) ids.splice(ids.indexOf(null),1 );
@@ -25,7 +68,7 @@ class Rampup {
     });
 
     const l = schedules.length;
-    let coaches = [];
+
 
     schedules.forEach(function (schedule) {
       

--- a/views/rebbl/league/rampup.pug
+++ b/views/rebbl/league/rampup.pug
@@ -51,6 +51,6 @@ block content
               div(class="col-1 Standings-divider--flex")
                 span(class="Standings-dividerText--correction")
               div(class="col-6 Standings-divider--flex" )
-                span(class="Standings-dividerText" style="font-size:1.5em")  &nbsp; &nbsp;Playoffs Cutoff &nbsp; &nbsp;
+                span(class="Standings-dividerText" style="font-size:1.5em")  &nbsp; &nbsp;Playins Cutin &nbsp; &nbsp;
               div(class="col-5 Standings-divider--flex")
                 span(class="Standings-dividerText--correction")


### PR DESCRIPTION
Rampup worked under the assumption that the rampup divs had the highest contestId. They do not anymore, so Rel 10F rampup coaches were shown as a seperate rampup div.