### PR TITLE
Cleaned up standings API

### DIFF
--- a/lib/DataService.js
+++ b/lib/DataService.js
@@ -312,9 +312,8 @@ class DataService{
     async getAccount(filter){
         return await this.accounts.findOne(filter);
     }
-
-    async getAccounts(filter){
-        return await this.accounts.find(filter).toArray();
+    async getAccounts(filter,projection){
+        return await this.accounts.find(filter,projection).toArray();
     }
 
     updateAccount(param,account,options){

--- a/lib/StandingsService.js
+++ b/lib/StandingsService.js
@@ -7,18 +7,10 @@ const
 class StandingsService{
     async newScore(league, comp, season, opponent, points, tdDiff){
 
-      const account = await dataService.getAccount({coach: opponent.coach.name});
-
-      //Tropyy and donations have nohting to with standings other than that thsoe are shown on the standings page
-      //Yes, you could have seperate API calls for those, but not really keen on adding roughly (2 * 20 * 14 =) 560 extra calls 
-      const showDonation = (account && account.donations && account.showDonation) ? true: false;
-      const trophy = (account && account.trophies) ? account.trophies.find(f => f.display) :null;
-      
+     
       return {
           id: opponent.coach.id,
           name: opponent.coach.name,
-          showDonation: showDonation,
-          trophy: trophy ? trophy: false,
           league: league,
           competition: comp,
           season: season,

--- a/routes/api/v2/api.js
+++ b/routes/api/v2/api.js
@@ -7,7 +7,8 @@ const express = require('express')
   , leagueApi = require("./league.js")
   , matchApi = require("./match.js")
   , standingsApi = require("./standings.js")
-  , teamApi = require("./team.js");
+  , teamApi = require("./team.js")
+  , trophiesApi = require("./trophies.js");
 
 class ApiV2{
   constructor(){
@@ -27,7 +28,9 @@ class ApiV2{
     this.router.use('/standings', new standingsApi().routesConfig());
     
     this.router.use('/team', new teamApi().routesConfig());
-    
+
+    this.router.use('/trophies', new trophiesApi().routesConfig());
+
     return this.router;
   }
 

--- a/routes/api/v2/trophies.js
+++ b/routes/api/v2/trophies.js
@@ -1,0 +1,60 @@
+
+'use strict';
+const dataService = require('../../../lib/DataService.js').rebbl
+  , configurationService = require('../../../lib/ConfigurationService.js')
+  , express = require('express')
+  , util = require('../../../lib/util.js');
+
+class Trophies{
+  constructor(){
+    this.router = express.Router({mergeParams: true});
+  }
+
+  routesConfig(){
+    this.router.get('/:league/:season', util.cache(600), async function(req, res){
+      try {
+        let standings = await dataService.getStandings({
+          "league":new RegExp(`^${req.params.league}$`,"i"), 
+          "season":new RegExp(`^${req.params.season}$`,"i")
+        });
+
+        let coaches = [...new Set(standings.map(s => s.name))];
+
+        let trophies = await dataService.getAccounts({coach:{$in:coaches},"trophies.display":true},{fields:{coach:1, trophies:1}});
+
+
+        res.json(trophies);
+      }
+      catch (ex){
+        console.error(ex);
+        res.status(500).send('Something something error');
+      }
+    
+    });
+
+    this.router.get('/:league/:season/donations', util.cache(600), async function(req, res){
+      try {
+        let standings = await dataService.getStandings({
+          "league":new RegExp(`^${req.params.league}$`,"i"), 
+          "season":new RegExp(`^${req.params.season}$`,"i")
+        });
+
+        let coaches = [...new Set(standings.map(s => s.name))];
+
+        let trophies = await dataService.getAccounts({coach:{$in:coaches},"showDonation":true},{fields:{coach:1}});
+
+        res.json(trophies.map(x => x.coach));
+      }
+      catch (ex){
+        console.error(ex);
+        res.status(500).send('Something something error');
+      }
+    
+    });
+    
+    return this.router;
+  }
+}
+
+
+module.exports = Trophies;

--- a/views/rebbl/standings/index.pug
+++ b/views/rebbl/standings/index.pug
@@ -50,13 +50,15 @@ block content
           div(class="col-1" data-bind="text:position")
           div(class="col-4" style=";overflow:hidden") 
             a(data-bind="text: name, attr:{href:`/rebbl/coach/${id}`}")
-            // ko if: showDonation
+            // ko if: $root.isDonator($data.name)
             | &nbsp; &nbsp; 
             img(src="/images/gold.png" style="height:25px;float:right;margin-top: 2px;" title="donator")
             // /ko
-            // ko if: $data.trophy 
+            // ko with: $root.getTrophy($data.name)
+            // ko if:$data
             | &nbsp; &nbsp; 
-            img(data-bind="attr:{src:`https://cdn2.rebbl.net/${trophy.filename}`, title:trophy.title, 'data-date':trophy.date}, click:$root.showTrophy"  style="height:25px;float:right;margin-top: 2px;cursor:pointer" class="trophy-toggle" data-target="#trophy" )
+            img(data-bind="attr:{src:`https://cdn2.rebbl.net/${$data.filename}`, title:$data.title, 'data-date':$data.date}, click:$root.showTrophy"  style="height:25px;float:right;margin-top: 2px;cursor:pointer" class="trophy-toggle" data-target="#trophy" )
+            // /ko
             // /ko
           div(class="col-7" style=";overflow:hidden") 
             a(data-bind="text: teamName(),attr:{href:`/rebbl/team/${teamId}`}")
@@ -148,13 +150,26 @@ block scripts
 
     class ViewModel{
       constructor(data){
+        this.donators = [];
         this.league = "";
+        this.season = "";
+        this.seasons = [];
         this.standings = {};
         this.tickets = [];
-        this.seasons = [];
-        this.season = "";
+        this.trophies =[];
+
         this.collator = new Intl.Collator(undefined, {numeric: true, sensitivity: "base"});
         ko.track(this);
+      }
+
+      getTrophy(coach){
+        let t = this.trophies.find(x => x.coach == coach);
+        if(t && t.trophies)return t.trophies.find(t => t.display);
+        return undefined;
+      }
+
+      isDonator(coach){
+        return this.donators.indexOf(coach)>-1;
       }
 
       competitionUrl(comp){
@@ -208,13 +223,45 @@ block scripts
           this.seasons = seasons
           this.season = seasons[seasons.length-1];
           this.loadSeason();
+          this.loadTrophies();
+          this.loadDonators();
         }.bind(this);
         xhr.send();
       }
 
+      loadTrophies(){
+        let xhr = new XMLHttpRequest();
+
+        xhr.open("GET", `/api/v2/trophies/${this.league}/${this.season}`,true)
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.responseType = 'json';
+
+        xhr.onload  = function() {
+          if (xhr.response) this.trophies = xhr.response;
+          else this.trophies = [];
+        }.bind(this);
+
+        xhr.send();
+      }
+
+      loadDonators(){
+        let xhr = new XMLHttpRequest();
+
+        xhr.open("GET", `/api/v2/trophies/${this.league}/${this.season}/donations`,true)
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.responseType = 'json';
+
+        xhr.onload  = function() {
+          if (xhr.response) this.donators = xhr.response;
+          else this.donators = [];
+        }.bind(this);
+
+        xhr.send();
+      }
+
       showTrophy(e){
-        $('#modal-title').text(e.trophy.title + (e.trophy.date.length > 0 ? " - " + e.trophy.date : "") );
-        $('#modal-image').attr('src',`https://cdn2.rebbl.net/${e.trophy.filename}`);
+        $('#modal-title').text(e.title + (e.date.length > 0 ? " - " + e.date : "") );
+        $('#modal-image').attr('src',`https://cdn2.rebbl.net/${e.filename}`);
         $('#trophy').modal();
       };
 
@@ -234,7 +281,5 @@ block scripts
       model.league = path[path.length-1];
       ko.applyBindings(model);
       model.loadSeasons();
-
-
     });
     


### PR DESCRIPTION
Standings had trophy and donations included in order to render those on the standings page.  I was not entirely pleased with that, realized how I could solve it after a rubber ducking session with Dreamifi.
Moved trophies to their own API, so first standings are loaded, and then trophies are applied.