### PR TITLE
Added teamId as searchcriteria for players

### DIFF
--- a/lib/teamservice.js
+++ b/lib/teamservice.js
@@ -335,7 +335,7 @@ class TeamService{
       if (currentPlayer.id ===null){
         player = await dataService.getPlayer({teamId:team.idteamlisting , name: currentPlayer.name});
       } else{
-        player = await dataService.getPlayer({id:currentPlayer.id});
+        player = await dataService.getPlayer({teamId:team.idteamlisting,id:currentPlayer.id});
       }
 
       if (!player) {


### PR DESCRIPTION
As described in #390, a player's stats can get wrong. Market player can exist more than once with the same `id`. So include `teamId` to get the correct player