### PR TITLE
Less aggressive syncning

### DIFF
--- a/lib/MaintenanceService.js
+++ b/lib/MaintenanceService.js
@@ -402,7 +402,8 @@ class MaintenanceService{
       date = `${date.getFullYear()}-${date.getMonth() +1}-${date.getDate()} ${date.getHours()}:${date.getMinutes()}:00`;
 
 
-      await Promise.each(leagues, async league=> {
+      for(let x =0; x < leagues.length;x++){
+        let league = leagues[x];
         let matches = await cyanideService.matches({platform:"pc","id_only":1, start:date, league:league});
 
         if (!matches) return;
@@ -422,7 +423,7 @@ class MaintenanceService{
 
         await Promise.each(data, m => dataService.insertMatch(m));
 
-      });
+      };
     }
 
 
@@ -458,8 +459,10 @@ class MaintenanceService{
         date = `${date.getFullYear()}-${date.getMonth() +1}-${date.getDate()} ${date.getHours()}:${date.getMinutes()}:00`;
 
 
-        await Promise.each(seasons, async season => {
-          await Promise.each(season.leagues, async league=> {
+        for(let x = 0;x < seasons.length;x++){
+          let season = seasons[x];
+          for(let y=0;y<season.leagues.length;y++){
+            let league=season.leagues[y];
             let matches = await cyanideService.matches({platform:"pc","id_only":1, start:date, /*competition:division,*/ league:league.name});
 
             if (!matches) return;
@@ -484,8 +487,10 @@ class MaintenanceService{
             let rounds = [...new Set(data.map(m => m.match.round))];
             //update competition fixtures
             let options = {platform:"pc", league : league.name, competition: "", round: 0, status:"played", exact: 1, limit:10};
-            await Promise.each(rounds, async round => 
-              await Promise.each(divisions, async division=>{
+            for(let i =0;i<rounds.length;i++){
+              let round = rounds[i];
+              for(let j=0;j<divisions.length;j++){
+                let division= divisions[j];
                 let swiss = null;
                 if(league.swiss)
                   swiss = league.swiss.find(function(a){return a.name === division});
@@ -567,20 +572,18 @@ class MaintenanceService{
                     },this));
                   }
                 }
-
                 //update standings
                 await standingsService.updateStandings(league.name, swiss ?  swiss.comp: division);
-              })
-            );
+              }
+            }
             let reg = new RegExp(encodeURI(`${league.name}/${season}`),"i")
             cache.keys().map(key => {
               if (reg.test(key)){
                 cache.del(key);
               }
             });
-
-          })
-        });
+          }
+        }
       }
       catch (e){
         loggingService.error(e);


### PR DESCRIPTION
a part of the timeouts from cyanide are (probably) occuring because the multiple request are send simultaneously to the /matches endpoint. This end point can take a while. Using a for loop will handle each league synchronously instead.