### PR TITLE
Fixed sunstraction of teamstats

### DIFF
--- a/lib/DataService.js
+++ b/lib/DataService.js
@@ -142,9 +142,18 @@ class DataService{
         }
         const key = {uuid:match.uuid};
 
+        match = match.hasOwnProperty("$set") ? match : {$set: match};
         try{
             this.matches.updateOne(key, match,{upsert:true});
         } catch(err){
+            console.error(err);
+        }
+    }
+
+    async deleteMatch(filter, options){
+        try{
+            return this.matches.deleteOne(filter, options);
+        }catch(err){
             console.error(err);
         }
     }

--- a/lib/MaintenanceService.js
+++ b/lib/MaintenanceService.js
@@ -355,20 +355,20 @@ class MaintenanceService{
     
         let contest = await dataService.getSchedule({contest_id: match.contest_id});
     
-        let contestHasWinner = contest && contest.winner !== null;
-        let matchHasWinner = match && match.winner !== null;
-    
+        const contestHasWinner = contest && contest.winner !== null;
+        const matchHasWinner = match && match.winner !== null;
+
         let mismatch = (!contestHasWinner && matchHasWinner || (contestHasWinner && matchHasWinner && contest.winner.coach.id !== match.winner.coach.id ));
     
-        if ( match.contest_id <= 187525 ){
-          return;  
-        } else if (!contest) {
+        if (!contest) {
           dataService.insertSchedule(match); 
         } else if(contest.manual) {
           return;
-        } else if (match.status === "played" && contest.match_uuid === null) {
+        } else if (match.status === "played" && (contest.match_uuid === null || mismatch)) {
           dataService.updateSchedule({contest_id: match.contest_id}, match);
-        } else if (match.status === "played" && mismatch) {
+        } else if (match.status === "played" && contest.match_uuid && contest.match_uuid !== match.match_uuid ) {
+          await teamService.substractMatch(contest.match_uuid);
+          dataService.deleteMatch({uuid:contest.match_uuid});
           dataService.updateSchedule({contest_id: match.contest_id}, match);
         } else if (match.status === "scheduled" && match.opponents && ((contest.opponents && (match.opponents[0].coach.id !== contest.opponents[0].coach.id
                   || match.opponents[1].coach.id !== contest.opponents[1].coach.id )) || !contest.opponents) ){

--- a/lib/teamservice.js
+++ b/lib/teamservice.js
@@ -243,7 +243,43 @@ class TeamService{
     dataService.updateTeam({_id:currentTeam._id},currentTeam);
   }
 
-  _updateTeamStats(team, currentTeam, opponent){
+  _updateTeamStats(team, currentTeam, opponent, substract){
+    if (substract){
+      team.stats.inflictedcasualties -= currentTeam.inflictedcasualties;
+      team.stats.inflictedpasses -= currentTeam.inflictedpasses;
+      team.stats.inflictedmeterspassing -= currentTeam.inflictedmeterspassing;
+      team.stats.inflictedtackles -= currentTeam.inflictedtackles;
+      team.stats.inflictedko -= currentTeam.inflictedko;
+      team.stats.inflicteddead -= currentTeam.inflicteddead;
+      team.stats.inflictedinterceptions -= currentTeam.inflictedinterceptions;
+      team.stats.inflictedcatches -= currentTeam.inflictedcatches;
+      team.stats.inflictedinjuries -= currentTeam.inflictedinjuries;
+      team.stats.inflictedmetersrunning -= currentTeam.inflictedmetersrunning;
+      team.stats.inflictedstuns-= team.stats.inflictedinjuries - team.stats.inflictedcasualties - team.stats.inflictedko;
+      team.stats.inflictedtouchdowns -= currentTeam.inflictedtouchdowns;
+      team.stats.sustainedexpulsions -= currentTeam.sustainedexpulsions;
+      team.stats.sustainedtouchdowns -= opponent.score;
+  
+      team.stats.sustainedinjuries -= currentTeam.sustainedinjuries;
+      team.stats.sustaineddead -= currentTeam.sustaineddead;
+      team.stats.sustainedko -= currentTeam.sustainedko;
+      team.stats.sustainedcasualties -= currentTeam.sustainedcasualties;
+      team.stats.sustainedpasses -= opponent.inflictedpasses;
+      team.stats.sustainedmeterspassing -= opponent.inflictedmeterspassing;
+      team.stats.sustainedcatches -= opponent.inflictedcatches;
+      team.stats.sustainedmetersrunning -= opponent.inflictedmetersrunning;
+  
+      team.stats.sustainedstuns-= team.stats.sustainedinjuries - team.stats.sustainedko - team.stats.sustainedcasualties;
+      team.stats.sustainedinterceptions -= opponent.inflictedinterceptions;
+      team.stats.sustainedtackles -= opponent.inflictedtackles;
+      team.stats.inflictedexpulsions -= opponent.sustainedexpulsions;
+      team.stats.cashearned -= currentTeam.cashearned;
+      team.stats.spirallingexpenses -= currentTeam.spirallingexpenses;
+      team.stats.nbsupporters -= currentTeam.nbsupporters;
+  
+      return team.stats;
+    }
+
     team.stats.inflictedcasualties += currentTeam.inflictedcasualties;
     team.stats.inflictedpasses += currentTeam.inflictedpasses;
     team.stats.inflictedmeterspassing += currentTeam.inflictedmeterspassing;
@@ -416,6 +452,53 @@ class TeamService{
     },this));
   }
 
+  async correctTeamPlayers(team){
+    if (!team.roster) return;
+    await Promise.all(team.roster.map(async function(currentPlayer){
+      let levels = [0,6,16,31,51,76,176,1000]
+      let player;
+      if (currentPlayer.id ===null){
+        player = await dataService.getPlayer({teamId:team.idteamlisting , name: currentPlayer.name});
+      } else{
+        player = await dataService.getPlayer({teamId:team.idteamlisting,id:currentPlayer.id});
+      }
+
+      if (player) {
+        if (!player.stats){
+          player.stats = currentPlayer.stats;
+        } else {
+          Object.keys( player.stats ).forEach( key => {
+            player.stats[key] -= currentPlayer.stats[key];
+            
+          });
+        }
+        player.matchplayed = (player.matchplayed || 0) - ( currentPlayer.matchplayed || 0);
+        player.xp_gain = (player.xp_gain || 0) - (currentPlayer.xp_gain || 0);
+        player.mvp = (player.mvp || 0) - (currentPlayer.mvp || 0);
+        
+        if(currentPlayer.casualties_sustained && player.casualties_sustained_total){
+          for(var cas of currentPlayer.casualties_sustained){
+            player.casualties_sustained_total.splice(-1,1);
+          }
+        }
+        
+        player.stats.inflictedstuns = player.stats.inflictedinjuries - player.stats.inflictedcasualties - player.stats.inflictedko; 
+        player.stats.sustainedstuns = player.stats.sustainedinjuries - player.stats.sustainedcasualties - player.stats.sustainedko; 
+
+        player.active = true;
+        player.level = 0;
+        if (player.casualties_sustained.indexOf("Dead")>-1){
+          player.active =false;
+          while (levels[player.level] < player.xp - player.xp_gain  ){
+            player.level = player.level+1;
+          }
+        }
+          
+        dataService.updatePlayer({_id:player._id},player);
+      }
+    },this));
+  }
+
 
   async quickFixPlayers(){
     let levels = [0,6,16,31,51,76,176,1000]
@@ -428,6 +511,47 @@ class TeamService{
       }
       dataService.updatePlayer({_id:player._id},player);
     });
+  }
+
+  async substractMatch(uuid){
+    const match = await dataService.getMatch({uuid:uuid});
+
+    let matchTeam1 = match.match.teams[0];
+    let matchTeam2 = match.match.teams[1];
+
+    cache.del(encodeURI(`/rebbl/team/${matchTeam1.idteamlisting}`));
+    cache.del(encodeURI(`/rebbl/team/${matchTeam2.idteamlisting}`));
+    cache.del(encodeURI(`/rebbl/coach/${match.match.coaches[0].idcoach}`));
+    cache.del(encodeURI(`/rebbl/coach/${match.match.coaches[1].idcoach}`));
+    cache.del(encodeURI(`/rebbl/coach/${match.match.coaches[0].idcoach}/matches`));
+    cache.del(encodeURI(`/rebbl/coach/${match.match.coaches[1].idcoach}/matches`));
+
+    let team1 = await this.getTeam(matchTeam1.idteamlisting);
+    let team2 = await this.getTeam(matchTeam2.idteamlisting);
+
+
+    if (!team1.stats) team1.stats={};
+    if (!team2.stats) team2.stats={};
+    await Promise.all(matchTeam1.roster.map(async function(player){
+      team1.stats.inflictedpushouts -= player.stats.inflictedpushouts;
+      team2.stats.sustainedpushouts -= player.stats.inflictedpushouts;
+    }));
+    await Promise.all(matchTeam2.roster.map(async function(player){
+      team2.stats.inflictedpushouts -= player.stats.inflictedpushouts;
+      team1.stats.sustainedpushouts -= player.stats.inflictedpushouts;
+    }));
+
+    team1.stats = this._updateTeamStats(team1, matchTeam1, matchTeam2);
+    team2.stats = this._updateTeamStats(team2, matchTeam2, matchTeam1);
+
+    dataService.updateTeam({_id:team1._id}, team1);
+    dataService.updateTeam({_id:team2._id}, team2);
+    
+    await this.correctTeamPlayers(matchTeam1);
+    await this.correctTeamPlayers(matchTeam2);
+
+    cache.del(encodeURI(`/rebbl/team/${matchTeam1.idteamlisting}`));
+    cache.del(encodeURI(`/rebbl/team/${matchTeam2.idteamlisting}`));
   }
 
 


### PR DESCRIPTION
When a game is reset, it gets a new uuid. The old game has already been processed stats-wise. Need to undo the stats of the old game.
closes #502