### PR TITLE
Docker compose support for Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ You need NodeJS and MongoDB to run this locally
 
 ## How to run using Docker
 
+⚠️**Important:** Windows 10 hosts must use [Linux containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
+
 1. Install [Docker](https://www.docker.com/get-started)
 2. Download the [Rebbel.net dump](https://cdn2.rebbl.net/rebbl.net/rebbl.tar.gz) and store it on this folder as `rebbl.tar.gz`
 3. Run `docker-compose build`

--- a/docker/Dockerfile-mongodb
+++ b/docker/Dockerfile-mongodb
@@ -4,4 +4,8 @@ FROM mongo:latest AS imports
 WORKDIR /usr/src/
 ADD rebbl.tar.gz /usr/src/rebbl
 ADD docker/mongodb.init.sh mongodb.init.sh
+
+# Converts DOS line endings to Unix
+RUN tr -d '\r' < mongodb.init.sh > mongodb.init.sh
+
 RUN chmod +x mongodb.init.sh


### PR DESCRIPTION
Added the following fixes:

* Added a warning about running the project on Windows 10. Only linux containers are supported.
* `mongodb.init.sh` line endings are automatically fixed. On Windows they get the wrong line endings after pulling the files using git so the script fixes this. This solution works well on unix hosts (Linux/OSX)